### PR TITLE
Sostituita proprietà display: none per favorire l'accessibilità

### DIFF
--- a/Sito/css/style.css
+++ b/Sito/css/style.css
@@ -129,16 +129,16 @@ body a:visited {
 
 #dropdown_content {
 	position: absolute;
-	right: -999em;
+	height: 0;
     overflow: hidden;
 }
 
 #dropbtn:hover + #dropdown_content {
-	right: 0;
+	height: auto;
 }
 
 #dropdown_content:hover {
-    right: 0;
+    height: auto;
 }
 
 #dropdown_content a {

--- a/Sito/css/style.css
+++ b/Sito/css/style.css
@@ -22,14 +22,14 @@ body a:visited {
 
 /*
  * Palette
- * 
+ *
  * backgroud-color: #1f1d1d
  * header footer backgroud-color: #4a0715
  * header h1 color: #e0ac00
  * menù li color: #f5e900
  * menù li:hover background-color: #33050e
  * menù li a:visited color: #e0ac00
- * 
+ *
  */
 
 
@@ -127,18 +127,18 @@ body a:visited {
 	background-color: #33050e;
 }
 
-#dropbtn:hover + #dropdown_content {
-	display: block;
+#dropdown_content {
+	position: absolute;
+	right: -999em;
+    overflow: hidden;
 }
 
-#dropdown_content {
-	display: none;
-	position: absolute;
+#dropbtn:hover + #dropdown_content {
 	right: 0;
 }
 
 #dropdown_content:hover {
-    display: block;
+    right: 0;
 }
 
 #dropdown_content a {


### PR DESCRIPTION
- Ho sistemato il menù dropdown sostituendo `display:  none;` con `right: -999em;` ed `overflow: hidden;` quando il menu doveva rimanere nascosto

- Ho messo inoltre `right: 0;` al posto di `display: block;` quando invece andava visualizzato il menu 