### PR TITLE
Font per la stampa

### DIFF
--- a/Sito/css/stampa.css
+++ b/Sito/css/stampa.css
@@ -2,6 +2,7 @@
 html, body {
     height: 97%;
     margin: 0;
+	font-family: "Times New Roman", Times, serif;
 }
 
 img {


### PR DESCRIPTION
Ho messo come font quelli che aveva messo anche la prof nel suo esempio delle slide. Non mi sembra cambi molto da quello che abbiamo nell'html. Comunque uno vale l'altro alla fine basta che non faccia schifo e che corregga l'errore dei xml:lang.
close #240