### PR TITLE
Fix .defaultTable in mobile.css, style.css e stampa.css

### DIFF
--- a/Sito/css/mobile.css
+++ b/Sito/css/mobile.css
@@ -62,11 +62,13 @@ body a:visited {
 /*	Tabelle	*/
 
 table.defaultTable {
-	width: 95%;
-	text-align: center;
+	display: block;
 	margin: 2em auto 1em;
 	border-collapse: separate;
 	border-spacing: 0 1em;
+	width: 95%;
+	overflow-x: auto;
+	text-align: center;
 }
 
 table.defaultTable td {
@@ -87,6 +89,7 @@ table.defaultTable tbody th:first-child {
 	border-top-left-radius: 16px;
 	border-bottom-left-radius: 16px;
 	border-left: solid 2px white;
+	padding: 0.5em;
 }
 
 table.defaultTable td:last-child {

--- a/Sito/css/stampa.css
+++ b/Sito/css/stampa.css
@@ -55,7 +55,7 @@ img {
 
 /*	Table Fritz	*/
 
-table.fritzTable {
+table.defaultTable {
 	width: calc(100% - 16em);
 	text-align: center;
 	margin: 2em 8em 1em;
@@ -63,27 +63,27 @@ table.fritzTable {
 	border-spacing: 0 1em;
 }
 
-table.fritzTable td {
+table.defaultTable td {
 	border: solid 1px black;
 	border-left: none;
 	border-right: none;
 	padding: 0.5em;
 }
 
-table.fritzTable td:first-child {
+table.defaultTable td:first-child {
 	border-top-left-radius: 16px;
 	border-bottom-left-radius: 16px;
 	border-left: solid 2px black;
 }
 
-table.fritzTable tbody th:first-child {
+table.defaultTable tbody th:first-child {
 	border: solid 1px black;
 	border-top-left-radius: 16px;
 	border-bottom-left-radius: 16px;
 	border-left: solid 2px black;
 }
 
-table.fritzTable td:last-child {
+table.defaultTable td:last-child {
 	border-top-right-radius: 16px;
 	border-bottom-right-radius: 16px;
 	border-right: solid 2px black;

--- a/Sito/css/style.css
+++ b/Sito/css/style.css
@@ -99,6 +99,7 @@ table.defaultTable tbody th:first-child {
 	border-top-left-radius: 16px;
 	border-bottom-left-radius: 16px;
 	border-left: solid 2px white;
+	padding: 0.5em;
 }
 
 table.defaultTable td:last-child {


### PR DESCRIPTION
Per ogni css aggiunto padding: 0.5em per il primo th in .defaultTable
Per mobile.css aggiunto anche display: block e overflow-x: auto così che se la tabella è più larga dello schermo si scrolla solo la tabella sull'asse delle x e non tutta la pagina