### PR TITLE
Fix Total Validator

### DIFF
--- a/Sito/login.html
+++ b/Sito/login.html
@@ -42,7 +42,7 @@
                     <input type="text" id="nomeUtente" name="username" placeholder="Utente" required="required"/>
                     <label for="passwordAcc" lang="en">Password:</label>
                     <input type="password" id="passwordAcc" name="password" placeholder="Password" required="required"/>
-                    <input class="defaultButton" type="submit" value="Accedi"/>
+                    <input class="defaultButton" type="submit" name="accedi" value="Accedi"/>
                 </fieldset>
             </form>
             <p>oppure</p>
@@ -62,7 +62,7 @@
                     <input type="password" id="passwordReg" name="password" required="required"/>
                     <label for="passwordRepeat">Ripeti la <span lang="en">password:</span></label>
                     <input type="password" id="passwordRepeat" name="passwordRepeat" required="required"/>
-                    <input class="defaultButton" type="submit" value="Registrati"/>
+                    <input class="defaultButton" type="submit" name="registrati" value="Registrati"/>
                 </fieldset>
             </form>
         </div>

--- a/Sito/pagamento.html
+++ b/Sito/pagamento.html
@@ -127,8 +127,8 @@
         </fieldset>
       </form>
 
-		<input class="defaultButton" type="button" value="Indietro" />
-		<input class="defaultButton" type="submit" value="Paga" />
+		<input class="defaultButton" type="button" name="indietro" value="Indietro" />
+		<input class="defaultButton" type="submit" name="paga" value="Paga" />
 
     </div>
 

--- a/Sito/recensioni.html
+++ b/Sito/recensioni.html
@@ -71,7 +71,7 @@
           <input type="text" id="titolo_recensione" name="titolo" />
 	  			<label for="testo_recensione">Testo: </label>
           <textarea id="testo_recensione" rows="5" cols="85"></textarea>
-          <input class="defaultButton" type="submit" value="Invia" />
+          <input class="defaultButton" type="submit" name="invia" value="Invia" />
         </fieldset>
       </form>
     </div>


### PR DESCRIPTION
A parte il fatto che Total Validator dice di usare le aria-label, ho solo aggiunto l'attributo `name=""` a degli input in cui mi segnava la mancanza. 
In alcune pagine mi segnalava di usare `<meta http-equiv="Content-Style-Type" content="text/css"/>` e poi il solito `<link rel="stylesheet" href="StockTrader.css" type="text/css" />`, ma cercando online ho visto che è obsoleto perchè veniva usato quando il css si metteva anche dentro l'html.
close #392 
close #377 
close #378 