### PR TITLE
Fix gestione_ordini e dettagli_ordine (utente e admin) in caso di destinazione eliminata

### DIFF
--- a/Sito/back/dettagli_ordine.php
+++ b/Sito/back/dettagli_ordine.php
@@ -11,14 +11,22 @@
 				$dettagliOrdine = $db->getDettagliOrdine($_GET['id_ordine']);
 				
 				if( is_object( $dettagliOrdine ) ) {
-					$content = '<h1>ID ordine: '.$dettagliOrdine->id_ordine.' - Username: '.$dettagliOrdine->username.'</h1>
-						<h2 class="data">Data ordine: '.$dettagliOrdine->data_ordine.'</h2>
-						<h2 class="data">Data consegna: '.$dettagliOrdine->data_consegna.'</h2>
+					if( $dettagliOrdine->id_destinazione != '' ) {
+						$content = '<h1>ID ordine: '.$dettagliOrdine->id_ordine.' - Username: '.$dettagliOrdine->username.'</h1>
+							<h2 class="data">Data ordine: '.$dettagliOrdine->data_ordine.'</h2>
+							<h2 class="data">Data consegna: '.$dettagliOrdine->data_consegna.'</h2>
 
-						<p>Destinazione:<br/>'.
-						$dettagliOrdine->nome_cognome.'<br/>Via '.
-						$dettagliOrdine->via.' '.$dettagliOrdine->numero_civico.' CAP '.$dettagliOrdine->CAP.'<br/>Tel: '.$dettagliOrdine->numero_telefonico.
-						'<table class="defaultTable" summary="Lista prodotti ordinati">
+							<p>Destinazione:<br/>'.
+							$dettagliOrdine->nome_cognome.'<br/>Via '.
+							$dettagliOrdine->via.' '.$dettagliOrdine->numero_civico.' CAP '.$dettagliOrdine->CAP.'<br/>Tel: '.$dettagliOrdine->numero_telefonico;
+					} else {
+						$content = '<h1>ID ordine: '.$dettagliOrdine->id_ordine.'</h1>
+							<h2 class="data">Data ordine: '.$dettagliOrdine->data_ordine.'</h2>
+							<h2 class="data">Data consegna: '.$dettagliOrdine->data_consegna.'</h2>
+
+							<p>La destinazione è stata eliminata<br/>';
+					}
+						$content .= '<table class="defaultTable" summary="Lista prodotti ordinati">
 							<thead>
 								<tr>
 									<th scope="col">Nome prodotto</th>

--- a/Sito/back/gestione_ordini.php
+++ b/Sito/back/gestione_ordini.php
@@ -13,7 +13,7 @@
 				$listaOrdini = '<dl class="defaultLista">';
 				
 				foreach( $ordini AS $row ) {
-					$listaOrdini .= '<dt class="idordine">ID ordine: '.$row->id_ordine.' - '.$row->username.'<a class="buttonSmall" href="dettagli_ordine.php?id_ordine='.$row->id_ordine.'">Dettagli Ordine</a></dt>
+					$listaOrdini .= '<dt class="idordine">ID ordine: '.$row->id_ordine.($row->username != '' ? ' - '.$row->username : '' ).'<a class="buttonSmall" href="dettagli_ordine.php?id_ordine='.$row->id_ordine.'">Dettagli Ordine</a></dt>
 					<dd>
 						<span>Data ordine: '.$row->data_ordine.'</span>
 						<span>Data consegna: '.$row->data_consegna.'</span>

--- a/Sito/php/dbaccess.php
+++ b/Sito/php/dbaccess.php
@@ -322,7 +322,11 @@
 		
 		public function getOrdini($username='') {
 			if($username == '') {
-				$query = $this->connection->prepare("SELECT O.*, U.username FROM Ordine O INNER JOIN Destinazione D ON O.destinazione = D.id_destinazione INNER JOIN Utente U ON D.utente = U.username ORDER BY O.data_ordine DESC");
+				$query = $this->connection->prepare("SELECT * FROM (
+					SELECT O.*, U.username FROM Ordine O INNER JOIN Destinazione D ON O.destinazione = D.id_destinazione INNER JOIN Utente U ON D.utente = U.username
+					UNION ALL
+					SELECT O.*, '' AS username FROM Ordine O WHERE O.destinazione IS NULL
+				) A ORDER BY A.data_ordine DESC");
 				$query->execute();
 				$queryResult = $query->get_result();
 			} else {
@@ -421,8 +425,12 @@
 					return -1;
 				}
 			} else {
-				$query = $this->connection->prepare("SELECT O.*, D.*, U.username FROM Ordine O INNER JOIN Destinazione D ON O.destinazione = D.id_destinazione INNER JOIN Utente U ON D.utente = U.username WHERE O.id_ordine = ?");
-				$query->bind_param('s',$id_ordine);
+				$query = $this->connection->prepare("SELECT * FROM (
+					SELECT O.*, D.*, U.username FROM Ordine O INNER JOIN Destinazione D ON O.destinazione = D.id_destinazione INNER JOIN Utente U ON D.utente = U.username WHERE O.id_ordine = ?
+					UNION ALL
+					SELECT O.*, '' AS id_destinazione, '' AS nome_cognome, '' AS numero_telefonico, '' AS CAP, '' AS via, '' AS numero_civico, '' AS utente, '' AS username FROM Ordine O WHERE O.id_ordine = ?
+				) A");
+				$query->bind_param('ss',$id_ordine,$id_ordine);
 				$query->execute();
 				//echo $query->info; exit;
 				$queryResult = $query->get_result();


### PR DESCRIPTION
In gestione ordini aggiunto il check per verificare se è stata eliminata la destinazione, in tal caso viene mostrato solo l'id_ordine
Per i dettagli in caso di utente se è stata eliminata la destinazione non viene mostrato l'ordine, se è admin viene mostrato l'ordine con destinazione  = 'La destinazione è stata eliminata' e username vuoti